### PR TITLE
fix disabling updated_at column in HasTimestamps trait

### DIFF
--- a/src/Models/Email.php
+++ b/src/Models/Email.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Email extends Model
 {
-    public $timestamps = ['created_at']; // only enable created_at
+    const UPDATED_AT = null;
 
     public function webhooks()
     {


### PR DESCRIPTION
Although set correctly in [the Webhook model](https://github.com/SynergiTech/laravel-postal/blob/75445c01984137d37a6a8163e690cd503643a2e9/src/Models/Email/Webhook.php#L10), we did not correctly set this in the Email model.

Resolves #6.