### PR TITLE
🐛 fix route notification for lookup

### DIFF
--- a/src/PostalNotificationChannel.php
+++ b/src/PostalNotificationChannel.php
@@ -46,6 +46,13 @@ class PostalNotificationChannel extends MailChannel
             $recipients = [$recipients];
         }
 
+        // if there are no recipients, its probable that the shorter `->notify()` form was used
+        if ($recipients === null) {
+            if (is_string($recipients = $notifiable->routeNotificationFor('postal', $notification))) {
+                $recipients = [$recipients];
+            }
+        }
+
         return collect($recipients)->mapWithKeys(function ($recipient, $email) {
             return is_numeric($email)
                     ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]

--- a/tests/ExampleNotifiableWithRouteMethod.php
+++ b/tests/ExampleNotifiableWithRouteMethod.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SynergiTech\Postal\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notifiable;
+use SynergiTech\Postal\Notifications\Emailable;
+
+class ExampleNotifiableWithRouteMethod extends Model
+{
+    use Notifiable, Emailable;
+
+    public $email = 'feature-test@example.com';
+
+    public function __construct()
+    {
+        $this->id = 1234;
+    }
+
+    public function routeNotificationForPostal($notification)
+    {
+        return $this->email;
+    }
+}

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -11,7 +11,7 @@ use SynergiTech\Postal\PostalTransport;
 
 class FeatureTest extends TestCase
 {
-    public function testSendingNotification()
+    public function testSendingNotificationLongForm()
     {
         $result = new \stdClass;
         $result->message_id = 'feature-test';
@@ -46,6 +46,47 @@ class FeatureTest extends TestCase
         $this->assertNotNull($email);
 
         $this->assertSame(ExampleNotifiable::class, $email->emailable_type);
+        $this->assertEquals($notifiable->id, $email->emailable_id);
+
+        $morph = $notifiable->emails()->get();
+        $this->assertCount(1, $morph);
+        $this->assertSame('feature-test@example.com', $morph[0]->to_email);
+    }
+
+    public function testSendingNotificationShortForm()
+    {
+        $result = new \stdClass;
+        $result->message_id = 'feature-test';
+        $message = new \stdClass();
+        $message->id = 'feature-test';
+        $message->token = 'feature-test';
+        $result->messages['feature-test@example.com'] = $message;
+
+        $clientMock = $this->createMock(Client::class);
+        $clientMock
+            ->method('makeRequest')
+            ->willReturn($result);
+
+        $this->app->afterResolving(TransportManager::class, function (TransportManager $manager) use ($clientMock) {
+            $manager->extend('postal', function () use ($clientMock) {
+                return new PostalTransport($clientMock);
+            });
+        });
+
+        $this->app->afterResolving(MailManager::class, function (MailManager $manager) use ($clientMock) {
+            $manager->extend('postal', function () use ($clientMock) {
+                return new PostalTransport($clientMock);
+            });
+        });
+
+        $notifiable = new ExampleNotifiableWithRouteMethod();
+        $notifiable->notify(new ExampleNotification($notifiable));
+
+        $emailModel = config('postal.models.email');
+        $email = $emailModel::where('to_email', 'feature-test@example.com')->first();
+        $this->assertNotNull($email);
+
+        $this->assertSame(ExampleNotifiableWithRouteMethod::class, $email->emailable_type);
         $this->assertEquals($notifiable->id, $email->emailable_id);
 
         $morph = $notifiable->emails()->get();

--- a/tests/PostalNotificationChannelTest.php
+++ b/tests/PostalNotificationChannelTest.php
@@ -27,7 +27,7 @@ class PostalNotificationChannelTest extends TestCase
         $nc->send('test', $notifyMock);
     }
 
-    public function testGetRecipients()
+    public function getRecipients($form)
     {
         $mailerMock = (class_exists(\Illuminate\Mail\MailManager::class))
             ? $this->createMock(\Illuminate\Mail\MailManager::class)
@@ -46,7 +46,13 @@ class PostalNotificationChannelTest extends TestCase
 
         $notifiableMock->expects($this->exactly(count($mockResponses)))
             ->method('routeNotificationFor')
-            ->with(PostalNotificationChannel::class, $notificationMock)
+            ->with(
+                $this->logicalOr(
+                    $form,
+                    PostalNotificationChannel::class
+                ),
+                $notificationMock
+            )
             ->will($this->onConsecutiveCalls(...$mockResponses));
 
         $nc = new PostalNotificationChannel($mailerMock, $markdownMock);
@@ -61,5 +67,15 @@ class PostalNotificationChannelTest extends TestCase
         foreach ($mockResponses as $response) {
             $this->assertSame(['getRecipientsTest@example.com'], $callProtectedFunction());
         }
+    }
+
+    public function testGetRecipientsLongForm()
+    {
+        $this->getRecipients(PostalNotificationChannel::class);
+    }
+
+    public function testGetRecipientsShortForm()
+    {
+        $this->getRecipients('postal');
     }
 }


### PR DESCRIPTION
Based on https://github.com/laravel/framework/blob/3ed487766b190ef626628f71de9a8ddf2b455a80/src/Illuminate/Notifications/RoutesNotifications.php#L42, sending the class name through tries to find a function called `routeNotificationForSynergiTech\Postal\PostalNotificationChannel` which is naturally invalid.

This fix allows a developer to specify `routeNotificationForPostal` on the model making use of the `Notifiable` trait and then use `$model->notify(...)`.