### PR TITLE
Reintroduce support for laravel 6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel: [6, 7, 8]
+        php: [7.3, 7.4, 8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: test against Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }}
+        run: docker build . --build-arg PHP_VERSION=${{ matrix.php }} --build-arg LARAVEL=${{ matrix.laravel }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 env:
+  - LARAVEL=6
   - LARAVEL=7
   - LARAVEL=8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ RUN apk add git zip unzip autoconf make g++
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 RUN curl -sS https://getcomposer.org/installer | php \
-    && mv composer.phar /usr/local/bin/composer \
-    && composer global require hirak/prestissimo
+    && mv composer.phar /usr/local/bin/composer
 
 WORKDIR /package
 
 COPY composer.json ./
 
-RUN composer install
+ARG LARAVEL=7
+RUN composer require laravel/framework ^$LARAVEL.0
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 [![Build Status](https://travis-ci.org/SynergiTech/laravel-postal.svg?branch=master)](https://travis-ci.org/SynergiTech/laravel-postal)
 [![codecov](https://codecov.io/gh/SynergiTech/laravel-postal/branch/master/graph/badge.svg)](https://codecov.io/gh/SynergiTech/laravel-postal)
 
-This library integrates [Postal](https://github.com/atech/postal) with the standard Laravel mail framework.
-
-Notice: Need this package for Laravel < 7? Use version 2.
+This library integrates [Postal](https://github.com/postalhq/postal) with the standard Laravel mail framework.
 
 ## Install
 
@@ -27,9 +25,9 @@ POSTAL_DOMAIN=https://your.postal.server
 POSTAL_KEY=yourapicredential
 ```
 
-Notice: if you're upgrading to Laravel 7, `MAIL_DRIVER` has become `MAIL_MAILER`.
+Notice: if you're using Laravel < 7, `MAIL_MAILER` should be `MAIL_DRIVER`.
 
-Finally, add postal as a mailer to your `config/mail.php` file
+Finally, if you're using Laravel 7 or later, add postal as a mailer to your `config/mail.php` file
 
 ```
 'mailers' => [
@@ -57,7 +55,7 @@ As this is a driver for the main Laravel Mail framework, sending emails is the s
 
 ## Upgrading
 ### Upgrading to V3
-If you are updating to Laravel 7, you will need to make use of version 3 to support the changes that have been made. Otherwise you should remain on version 2.
+If you are updating to Laravel 7 as well, you will need to update your environment variable names.
 
 ### Upgrading from V1 to V2
 **Please note** version 2 is backwards compatible with version 1 as long as you are not using a listener. Version 2 is also configured differently and includes many more features (including support for webhooks) so if you're upgrading from version 1, please take time to re-read this information.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ vendor/bin/phpunit -c phpunit.xml
 You will need xdebug installed to generate code coverage.
 
 ### Docker
-A sample Dockerfile is provided to setup an environment to run the tests without configuring your local machine. The Dockerfile can take a PHP version as an argument to test multiple versions.
+A sample Dockerfile is provided to setup an environment to run the tests without configuring your local machine. The Dockerfile can test multiple combinations of versions for PHP and Laravel via arguments.
+
 ```
-docker build . --build-arg PHP_VERSION=7.3
+docker build . --build-arg PHP_VERSION=7.3 --build-arg LARAVEL=7
 ```

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     "license": "MIT",
     "require": {
         "php": "^7.3",
-        "laravel/framework": "^7.0|^8.0",
+        "laravel/framework": "^6.0|7.0|^8.0",
         "postal/postal": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "orchestra/testbench": "^5.1|^6.0"
+        "orchestra/testbench": "^4.0|^5.1|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://github.com/synergitech/laravel-postal",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "laravel/framework": "^6.0|7.0|^8.0",
         "postal/postal": "^1.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
         <server name="APP_ENV" value="testing"/>
         <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
         <server name="DB_CONNECTION" value="testing"/>
+        <server name="MAIL_DRIVER" value="postal"/>
         <server name="MAIL_MAILER" value="postal"/>
     </php>
     <filter>

--- a/src/PostalServiceProvider.php
+++ b/src/PostalServiceProvider.php
@@ -3,6 +3,7 @@
 namespace SynergiTech\Postal;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Mail\TransportManager;
 use Illuminate\Mail\MailManager;
 use Postal\Client;
 
@@ -36,8 +37,20 @@ class PostalServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->afterResolving(TransportManager::class, function (TransportManager $manager) {
+            $this->extendTransportManager($manager);
+        });
+
         $this->app->afterResolving(MailManager::class, function (MailManager $manager) {
             $this->extendMailManager($manager);
+        });
+    }
+
+    public function extendTransportManager(TransportManager $manager)
+    {
+        $manager->extend('postal', function () {
+            $config = config('postal', []);
+            return new PostalTransport(new Client($config['domain'] ?? null, $config['key'] ?? null));
         });
     }
 

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -2,6 +2,7 @@
 
 namespace SynergiTech\Postal\Tests;
 
+use Illuminate\Mail\TransportManager;
 use Illuminate\Mail\MailManager;
 use Illuminate\Support\Facades\Notification;
 use Postal\Client;
@@ -23,6 +24,12 @@ class FeatureTest extends TestCase
         $clientMock
             ->method('makeRequest')
             ->willReturn($result);
+
+        $this->app->afterResolving(TransportManager::class, function (TransportManager $manager) use ($clientMock) {
+            $manager->extend('postal', function () use ($clientMock) {
+                return new PostalTransport($clientMock);
+            });
+        });
 
         $this->app->afterResolving(MailManager::class, function (MailManager $manager) use ($clientMock) {
             $manager->extend('postal', function () use ($clientMock) {

--- a/tests/PostalNotificationChannelTest.php
+++ b/tests/PostalNotificationChannelTest.php
@@ -9,7 +9,9 @@ class PostalNotificationChannelTest extends TestCase
 {
     public function testSend()
     {
-        $mailerMock = $this->createMock(\Illuminate\Mail\MailManager::class);
+        $mailerMock = (class_exists(\Illuminate\Mail\MailManager::class))
+            ? $this->createMock(\Illuminate\Mail\MailManager::class)
+            : $this->createMock(\Illuminate\Mail\Mailer::class);
         $markdownMock = $this->createMock(\Illuminate\Mail\Markdown::class);
         $notifyMock = $this->createMock(ExampleNotification::class);
 
@@ -27,7 +29,9 @@ class PostalNotificationChannelTest extends TestCase
 
     public function testGetRecipients()
     {
-        $mailerMock = $this->createMock(\Illuminate\Mail\MailManager::class);
+        $mailerMock = (class_exists(\Illuminate\Mail\MailManager::class))
+            ? $this->createMock(\Illuminate\Mail\MailManager::class)
+            : $this->createMock(\Illuminate\Mail\Mailer::class);
         $markdownMock = $this->createMock(\Illuminate\Mail\Markdown::class);
         $notificationMock = $this->createMock(ExampleNotification::class);
         $notifiableMock = $this->createMock(\Illuminate\Notifications\AnonymousNotifiable::class);

--- a/tests/PostalServiceProviderTest.php
+++ b/tests/PostalServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace SynergiTech\Postal\Tests;
 
+use Illuminate\Mail\TransportManager;
 use Illuminate\Mail\MailManager;
 use SynergiTech\Postal\PostalServiceProvider;
 use SynergiTech\Postal\PostalTransport;
@@ -11,10 +12,17 @@ class PostalServiceProviderTest extends TestCase
     public function testRegister()
     {
         $serviceProvider = new PostalServiceProvider($this->app);
-        $mailManager = new MailManager($this->app);
-        $serviceProvider->extendMailManager($mailManager);
 
-        $driver = $mailManager->createTransport(config('mail.mailers.postal'));
+        if (class_exists(TransportManager::class)) {
+            $transportManager = new TransportManager($this->app);
+            $serviceProvider->extendTransportManager($transportManager);
+            $driver = $transportManager->driver('postal');
+        } else {
+            $mailManager = new MailManager($this->app);
+            $serviceProvider->extendMailManager($mailManager);
+            $driver = $mailManager->createTransport(config('mail.mailers.postal'));
+        }
+
         $this->assertInstanceOf(PostalTransport::class, $driver);
     }
 }

--- a/tests/PostalTransportTest.php
+++ b/tests/PostalTransportTest.php
@@ -6,6 +6,7 @@ use Postal\Client;
 use Postal\Error;
 use Postal\SendResult;
 use SynergiTech\Postal\PostalTransport;
+use Illuminate\Mail\TransportManager;
 use Illuminate\Mail\MailManager;
 use SynergiTech\Postal\PostalNotificationChannel;
 use Illuminate\Support\Facades\Notification;
@@ -109,9 +110,14 @@ class PostalTransportTest extends TestCase
             ->method('makeRequest')
             ->willReturn($result);
 
+        $this->app->afterResolving(TransportManager::class, function (TransportManager $manager) use ($clientMock) {
+                $manager->extend('postal', function () use ($clientMock) {
+                return new PostalTransport($clientMock);
+            });
+        });
+
         $this->app->afterResolving(MailManager::class, function (MailManager $manager) use ($clientMock) {
             $manager->extend('postal', function () use ($clientMock) {
-                $config = config('postal', []);
                 return new PostalTransport($clientMock);
             });
         });


### PR DESCRIPTION
resolves #22 

It was roughly as easy as discussed, interestingly I had to test for the Mailer class _second_ in order for the tests to pass.