### PR TITLE
✨ use the models, which can be overridden, to provide table names

### DIFF
--- a/migrations/2019_07_12_132900_postal_create_email_table.php
+++ b/migrations/2019_07_12_132900_postal_create_email_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class PostalCreateEmailTable extends Migration
 {
@@ -13,11 +13,14 @@ class PostalCreateEmailTable extends Migration
      */
     public function up()
     {
-        if (Schema::hasTable('emails')) {
+        $model = config('postal.models.email');
+        $table = (new $model())->getTable();
+
+        if (Schema::hasTable($table)) {
             return;
         }
 
-        Schema::create('emails', function (Blueprint $table) {
+        Schema::create($table, function (Blueprint $table) {
             $table->bigIncrements('id');
 
             $table->string('to_name')->nullable();
@@ -54,6 +57,9 @@ class PostalCreateEmailTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('emails');
+        $model = config('postal.models.email');
+        $table = (new $model())->getTable();
+
+        Schema::dropIfExists($table);
     }
 }

--- a/migrations/2019_07_12_132901_postal_create_email_webhook_table.php
+++ b/migrations/2019_07_12_132901_postal_create_email_webhook_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class PostalCreateEmailWebhookTable extends Migration
 {
@@ -13,11 +13,14 @@ class PostalCreateEmailWebhookTable extends Migration
      */
     public function up()
     {
-        if (Schema::hasTable('email_webhooks')) {
+        $model = config('postal.models.webhook');
+        $table = (new $model())->getTable();
+
+        if (Schema::hasTable($table)) {
             return;
         }
 
-        Schema::create('email_webhooks', function (Blueprint $table) {
+        Schema::create($table, function (Blueprint $table) {
             $table->bigIncrements('id');
 
             $table->unsignedBigInteger('email_id');
@@ -38,6 +41,9 @@ class PostalCreateEmailWebhookTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('email_webhooks');
+        $model = config('postal.models.webhook');
+        $table = (new $model())->getTable();
+
+        Schema::dropIfExists($table);
     }
 }


### PR DESCRIPTION
Some projects that this library is introduced to may already have an `emails` table so we need to provide a way to allow the migrations to execute safely and this library to still function.

Since table names are already customisable via models and this library allows the developer to specify a different model then we can use that configuration item to retrieve the table name from the model.

The resulting model in the developers code could look like

```php
<?php

namespace App\Models;

class PostalEmails extends \SynergiTech\Postal\Models\Email
{
    /** @var string */
    protected $table = 'postal_emails';
}
```