### PR TITLE
🐛 need to initialise null parameters

### DIFF
--- a/src/PostalTransport.php
+++ b/src/PostalTransport.php
@@ -22,6 +22,7 @@ class PostalTransport extends AbstractTransport
         protected Client $client
     )
     {
+        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
I'm not sure if this changed since we created the new release for Laravel 9 but we detected this issue whilst making use of the notification channel.

![image](https://user-images.githubusercontent.com/1619102/177307054-d6a28991-396f-427d-adb2-cadcabba2bd5.png)

The resolution is to make use of the parent constructor to initialise the variables (as null) as per [Symfonys SMTPTransport](https://github.com/symfony/mailer/blob/7ceb67897f603dc3d26f3671b42cc29fe6c4aee7/Transport/Smtp/SmtpTransport.php#L45)